### PR TITLE
feat: ✨ scope to allow digit

### DIFF
--- a/__tests__/conventional-commits.ts
+++ b/__tests__/conventional-commits.ts
@@ -131,3 +131,18 @@ test("multi log & commit", () => {
     expect(cc.formatLog(cc.formatLog(cc.formatLog(input)))).toBe(output)
   }
 })
+
+
+test("lowercase scope that include numbers", () => {
+  const cc = new ConventionalCommits(new Devmoji(new Config()))
+  expect(cc.formatCommit("feat(jira-123): testing")).toBe(
+    "feat(jira-123): ✨ testing"
+  )
+})
+
+test("uppercase scope that include numbers", () => {
+  const cc = new ConventionalCommits(new Devmoji(new Config()))
+  expect(cc.formatCommit("feat(JIRA-123): testing")).toBe(
+    "feat(JIRA-123): ✨ testing"
+  )
+})

--- a/__tests__/lint.ts
+++ b/__tests__/lint.ts
@@ -25,7 +25,9 @@ test("should", async () => {
   chore(release): 2.1.5 [skip ci]
   docs: fixed config example
   feat(TextInput): add new variant
-  chore(deps): update dependency rollup to v2 (#35)`
+  chore(deps): update dependency rollup to v2 (#35)
+  feat(JIRA-123): add new variant
+  feat(jira-123): add new variant
     .split("\n")
     .map((s) => s.trim())
   for (const msg of valid) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ export class Cli {
     if (/^([rR]evert)/.test(text)) return []
 
     const errors = []
-    const match = /^(?<type>:?[a-z-]+)(?:\((?<scope>[a-z-]+)\))?(!?):\s+(?<description>.*)/iu.exec(
+    const match = /^(?<type>:?[a-z-]+)(?:\((?<scope>[a-z-0-9]+)\))?(!?):\s+(?<description>.*)/iu.exec(
       text
     )
     if (match) {

--- a/src/conventional-commits.ts
+++ b/src/conventional-commits.ts
@@ -2,7 +2,7 @@ import { Devmoji } from "./devmoji"
 import chalk from "chalk"
 
 export class ConventionalCommits {
-  regex = /(?<type>:?[a-z-]+)(?:\((?<scope>[a-z-]+)\))?(!?):\s*(?:(?<other>(?::[a-z-]+:\s*)+)\s*)?/gmu
+  regex = /(?<type>:?[a-z-]+)(?:\((?<scope>[a-z-0-9]+)\))?(!?):\s*(?:(?<other>(?::[a-z-]+:\s*)+)\s*)?/gmui
   constructor(public devmoji: Devmoji) {}
 
   formatCommit(text: string, color = false) {


### PR DESCRIPTION
as per [conventional-commits](https://github.com/conventional-commits/parser#the-grammar ), scope allows number digits
`<scope>           ::= <any UTF8-octets except newline or parens>+`


made changes to modify regex to allow number  digit.

as part of our practice , we are putting the jira ticket as scope, and with the existing code the lint is failing during the pre commit check (`npx devmoji -e --lint`)
