### PR TITLE
feat: Skip lint when merging remote branch

### DIFF
--- a/__tests__/lint.ts
+++ b/__tests__/lint.ts
@@ -7,6 +7,7 @@ test("should", async () => {
   squash!
   revert something
   Merge branch 'master' of github.com:folke/devmoji
+  Merge remote-tracking branch 'master' of github.com:folke/devmoji
   style: 🎨 Prettier 2.0
   chore(release): 2.1.8 [skip ci]
   fix(deps): update dependency chalk to v4 (#49)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ export class Cli {
 
   lint(text: string) {
     text = text.split("\n")[0]
-    if (text.startsWith("Merge branch")) return []
+    if (/^(Merge (remote-tracking )?branch)/.test(text)) return []
     if (/^(fixup|squash)!/.test(text)) return []
     if (/^([rR]evert)/.test(text)) return []
 


### PR DESCRIPTION
# Description

When merging a remote branch `(origin/master)` directly into the local branch `(feature/branch-abc)`, the default git commits message will be `"Merge remote-tracking branch 'origin/master'  into feature/branch-abc"`. 

Current lint doesn't cover this use case, so the commit message format is validated against the `conventional commit` standards and getting blocked.

This PR includes a `regex` to skip the git merge default commit message from linting.



